### PR TITLE
scoreboard qol improvements

### DIFF
--- a/EnoLandingPageFrontend/Pages/ScoreboardView.razor
+++ b/EnoLandingPageFrontend/Pages/ScoreboardView.razor
@@ -222,7 +222,7 @@
                         <div class="team-logo-container">
                             <img src="@team.LogoUrl" class="team-logo" referrerpolicy="no-referrer" />
                         </div>
-                        <div class="team-name"><a href="/scoreboard/team/@team.TeamId">@team.TeamName</a></div>
+                        <div class="team-name"><a href="/scoreboard/team/@team.TeamId">@team.TeamName (#@team.TeamId)</a></div>
                         <img src="@countryUrl" class="team-countryflag" referrerpolicy="no-referrer" />
                     </div>
                 </td>

--- a/EnoLandingPageFrontend/Pages/ScoreboardView.razor
+++ b/EnoLandingPageFrontend/Pages/ScoreboardView.razor
@@ -211,7 +211,7 @@
             string? countryUrl = null;
             if (team.CountryCode != null && team.CountryCode != string.Empty)
             {
-                countryUrl = $"https://cdn.ipregistry.co/flags/wikimedia/{team.CountryCode?.ToLower()}.png";
+                countryUrl = $"https://cdn.jsdelivr.net/npm/country-flag-icons@latest/3x2/{team.CountryCode?.ToUpper()}.svg";
             }
             var orderedTeamServiceDetails = team.ServiceDetails.OrderBy(sd => sd.ServiceId).ToArray();
             var previousRoundTeam = previousScoreboard?.Teams.Where(t => t.TeamId == team.TeamId).Single();

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## docker-compose
 ```yaml
-version: '3'
-
 services:
   enolandingpage:
     build: .

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ services:
     ports:
       - "5001:80"
     volumes:
-      - ./sessions:/root/.aspnet/DataProtection-Keys
-      - ./data:/app/data
-      - ./scoreboard:/app/wwwroot/scoreboard
+      - ./sessions:/root/.aspnet/DataProtection-Keys:Z
+      - ./data:/app/data:Z
+      - ./scoreboard:/app/wwwroot/scoreboard:Z
 ```
 
 ## VM Placement


### PR DESCRIPTION
+ show team id on score board prefixed with # to make teams searchable by their id
+ switch country flag source
ipregistry.co is on firefox's tracker list, so it blocks it by default. use jsdelivr instead
+ update Readme.md. docker compose version is deprecated

change from:
<img width="397" height="786" alt="Screenshot_20260719_211341" src="https://github.com/user-attachments/assets/e63e08d4-4661-405b-ad04-b1eabf5537f9" />

to:
<img width="397" height="786" alt="Screenshot_20260719_211234" src="https://github.com/user-attachments/assets/e1156ace-6696-4265-ad6f-047de2b2b17f" />
